### PR TITLE
Embed link to wiki item page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord
 pyinstaller
 pygsheets
 pytz
+beautifulsoup4

--- a/src/IkBot.py
+++ b/src/IkBot.py
@@ -5,6 +5,7 @@ import random
 import re
 import threading
 import time
+import WikiScraper
 from datetime import datetime
 
 import discord
@@ -52,7 +53,7 @@ if ENABLE_GOOGLE_SHEET:
     
 else:
     target_list  = ["testSpider"]
-    item_list    = ["testSword"]
+    item_list    = ["Iksar Berserker Club"]
     trade_list   = ["testCraft"]
     roster_list  = ["testIksar"]
     taunt_death_list = ["testFAILURE"]
@@ -318,11 +319,19 @@ class EverquestLogFile:
                         for member in self.roster_name_list for item in quest_list
                         if member.lower() in command[0] and item.lower() in command[3]]:
                 return event[0]
+    
+    # create (guess) the link to the item on the wiki
+    def link_to_Wiki(self, itemName):
+        wiki_url_prefix = "https://wiki.project1999.com/"
+        wiki_url_item_guess = itemName.replace(" ", "_")
+        return wiki_url_prefix + wiki_url_item_guess
 
             
             
 # create the global instance of the log file class
 elf = EverquestLogFile()
+# create the global instance of the web scraping class
+scraper = WikiScraper.WikiScraper()
 
 #################################################################################################
 
@@ -380,11 +389,20 @@ async def parse():
 
                 # Notable Loot
                 elif 'Loot' in event[0]:
+                    wiki_link = elf.link_to_Wiki(event[2])
+                    embed = None
+                    try:
+                        embed = discord.Embed(
+                        title=event[2],
+                        url=wiki_link,
+                        description=scraper.scrape_wikipage_item(wiki_link))
+                    except: 
+                        print("failed to parse " + wiki_link)
                     to_send = f"{event[1]} just looted the {event[2]} for me! Leave it with the War Baron and he'll get it to me."
                     if event[1] != elf.char_name:
                         await asyncio.sleep(random.randint(1,11))
                     if to_send != client.content:
-                        await client.alarm(to_send)
+                        await client.alarm(to_send, embed)
 
                 # IkBot Item
                 elif 'Quest' in event[0]:
@@ -427,8 +445,8 @@ class myClient(commands.Bot):
         self.logging_channel = self.get_channel(myconfig.DISCORD_SERVER_CHANNELID)
 
     # sound the alarm
-    async def alarm(self, msg):
-        await self.logging_channel.send(msg)
+    async def alarm(self, msg, embd=None):
+        await self.logging_channel.send(msg, embed=embd)
 
         print(f'Alarm:{msg}')
 

--- a/src/WikiScraper.py
+++ b/src/WikiScraper.py
@@ -1,0 +1,33 @@
+import requests
+from bs4 import BeautifulSoup
+
+class WikiScraper:
+
+    def __init__(self):
+        self.name = "WikiScraper"
+
+    # only returns item description at the moment, but may try to parse more (ex: image)
+    def scrape_wikipage_item(self, url):
+        # this requests.get() uses https and complains about not finding a certificate
+        #page = requests.get(url)
+        
+        # this does not use HTTPS so it does not look for certificate
+        page = requests.get(url, verify=False)
+        soup = BeautifulSoup(page.content, "html.parser")
+        
+        return self.parse_description(soup)
+
+    # gets the item/weapon description text
+    def parse_description(self, page_text):
+        results = page_text.find(id="mw-content-text")
+        job_elements = results.find("div", class_="itemdata")
+        paragraph = job_elements.find("p")
+        return paragraph.text
+
+    # gets weapon/item icon img source URL (currently not showing up in embeds)
+    def parse_icon(self, page_text):
+        results = page_text.find("div", class_="itemicon")
+        icon_srcs = results.find("img")
+        icon_src = icon_srcs['src']
+        return "https://wiki.project1999.com" + icon_src
+


### PR DESCRIPTION
Should post an embedded link to the item on the wiki
It guesses the link by taking the item name "Iksar Berserker Club" and replace " " with "_" (Iksar_Berserker_Club) which should work for many items
It parses the page for the description of the item and posts it in the embedded message to discord.

Bug: requests.get(URL) in WikiScraper.py should use HTTPS but requires a cert file I failed to figure out how to find/fix
my solution: use requests.get(URL, verify=False) which doesnt care about the S in HTTPS but the package complains about not being secure. That warning shows up in the terminal output.
